### PR TITLE
Change TAROPTS to gzip.

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -339,7 +339,7 @@ rm "$chroot_dir/etc/resolv.conf"
 umount "$chroot_dir/proc"
 
 ### create a tar archive from the chroot directory
-TAROPTS="cf"
+TAROPTS="cfz"
 if [ "${tarball}" == "*z" ]; then
     TAROPTS="${TAROPTS}z"
 fi


### PR DESCRIPTION
Creating the final tar.gz file does not actually gzip the package, this is due to missing `z` option in the TAROPTS.